### PR TITLE
feat: forgot password flow via Supabase implicit recovery

### DIFF
--- a/apps/api/src/auth/router.py
+++ b/apps/api/src/auth/router.py
@@ -4,8 +4,11 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from src.auth.dependencies import get_auth_service, get_current_user
 from src.auth.schemas import (
     ConfirmRequest,
+    ForgotPasswordRequest,
+    ForgotPasswordResponse,
     IdTokenSignInRequest,
     RefreshTokenRequest,
+    ResetPasswordRequest,
     SignInRequest,
     SignOutRequest,
     SignUpRequest,
@@ -104,3 +107,30 @@ async def sign_out(
 async def me(current_user: UserModel = Depends(get_current_user)):
     """Return the authenticated user's local profile."""
     return current_user
+
+
+@router.post("/forgot-password", response_model=ForgotPasswordResponse)
+async def forgot_password(
+    data: ForgotPasswordRequest,
+    service: AuthService = Depends(get_auth_service),
+):
+    """
+    Send a password reset email.
+
+    Always returns ok regardless of whether the email exists to prevent
+    email enumeration attacks.
+    """
+    return await service.forgot_password(data)
+
+
+@router.post("/reset-password", response_model=TokenResponse)
+async def reset_password(
+    data: ResetPasswordRequest,
+    service: AuthService = Depends(get_auth_service),
+):
+    """
+    Verify a password-reset OTP token, set a new password, and return a fresh session.
+
+    Returns 400 EXPIRED_OR_INVALID_TOKEN if the token_hash is invalid or expired.
+    """
+    return await service.reset_password(data)

--- a/apps/api/src/auth/schemas.py
+++ b/apps/api/src/auth/schemas.py
@@ -64,3 +64,18 @@ class UserMeResponse(BaseModel):
     plan: str = "free"
 
     model_config = {"from_attributes": True}
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+    redirect_to: str
+
+
+class ForgotPasswordResponse(BaseModel):
+    message: str = "ok"
+
+
+class ResetPasswordRequest(BaseModel):
+    access_token: str
+    refresh_token: str
+    new_password: str

--- a/apps/api/src/auth/services.py
+++ b/apps/api/src/auth/services.py
@@ -5,8 +5,11 @@ from supabase import AsyncClient
 from src.user.models import UserModel
 from src.user.repository import UserRepository
 from src.auth.schemas import (
+    ForgotPasswordRequest,
+    ForgotPasswordResponse,
     IdTokenSignInRequest,
     RefreshTokenRequest,
+    ResetPasswordRequest,
     SignInRequest,
     SignUpRequest,
     TokenResponse,
@@ -250,3 +253,49 @@ class AuthService:
             await self.supabase.auth.sign_out()
         except AuthApiError as e:
             raise HTTPException(status_code=e.status or 500, detail=e.message)
+
+    async def forgot_password(self, data: ForgotPasswordRequest) -> ForgotPasswordResponse:
+        """Send a password reset email. Always returns ok to prevent email enumeration."""
+        try:
+            await self.supabase.auth.reset_password_for_email(
+                data.email, {"redirect_to": data.redirect_to}
+            )
+        except AuthApiError:
+            pass
+        return ForgotPasswordResponse()
+
+    async def reset_password(self, data: ResetPasswordRequest) -> TokenResponse:
+        """Set session from recovery tokens, update password, and return a fresh session."""
+        try:
+            response = await self.supabase.auth.set_session(data.access_token, data.refresh_token)
+        except AuthApiError:
+            raise HTTPException(status_code=400, detail="EXPIRED_OR_INVALID_TOKEN")
+
+        if not response.session or not response.user:
+            raise HTTPException(status_code=400, detail="EXPIRED_OR_INVALID_TOKEN")
+
+        session = response.session
+        supabase_user = response.user
+
+        try:
+            await self.supabase.auth.update_user({"password": data.new_password})
+        except AuthApiError as e:
+            raise HTTPException(status_code=e.status or 400, detail=e.message)
+
+        meta = supabase_user.user_metadata or {}
+        local_user = await self._sync_user(
+            supabase_user_id=str(supabase_user.id),
+            email=str(supabase_user.email),
+            name=meta.get("name", str(supabase_user.email).split("@")[0]),
+            currency=meta.get("currency", "COP"),
+        )
+        await self.user_repository.db.commit()
+
+        return self._build_token_response(
+            session=session,
+            user_id=str(supabase_user.id),
+            email=str(supabase_user.email),
+            name=local_user.name,
+            currency=local_user.currency,
+            plan=local_user.plan,
+        )

--- a/apps/web/app/[locale]/auth/reset-password/page.tsx
+++ b/apps/web/app/[locale]/auth/reset-password/page.tsx
@@ -1,0 +1,5 @@
+import { ResetPasswordClient } from "./reset-password-client"
+
+export default function ResetPasswordPage() {
+  return <ResetPasswordClient />
+}

--- a/apps/web/app/[locale]/auth/reset-password/reset-password-client.tsx
+++ b/apps/web/app/[locale]/auth/reset-password/reset-password-client.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { signIn } from "next-auth/react"
+import { useTranslations } from "next-intl"
+import { useRouter } from "@/i18n/navigation"
+import { Link } from "@/i18n/navigation"
+import { useForm } from "@tanstack/react-form"
+
+import { Button } from "@workspace/ui/components/button"
+import { Card, CardContent, CardHeader } from "@workspace/ui/components/card"
+import {
+  Field,
+  FieldGroup,
+  FieldLabel,
+} from "@workspace/ui/components/field"
+import { Input } from "@workspace/ui/components/input"
+
+type State = "loading" | "idle" | "submitting" | "error"
+
+interface Tokens {
+  access_token: string
+  refresh_token: string
+}
+
+export function ResetPasswordClient() {
+  const router = useRouter()
+  const t = useTranslations("auth")
+  const [state, setState] = useState<State>("loading")
+  const [errorMessage, setErrorMessage] = useState<string>("")
+  const [tokens, setTokens] = useState<Tokens | null>(null)
+
+  useEffect(() => {
+    const hash = window.location.hash.slice(1)
+    const params = new URLSearchParams(hash)
+    const accessToken = params.get("access_token")
+    const refreshToken = params.get("refresh_token")
+    const type = params.get("type")
+
+    if (!accessToken || !refreshToken || type !== "recovery") {
+      setErrorMessage(t("resetLinkExpired"))
+      setState("error")
+      return
+    }
+
+    setTokens({ access_token: accessToken, refresh_token: refreshToken })
+    setState("idle")
+  }, [t])
+
+  const form = useForm({
+    defaultValues: {
+      new_password: "",
+      confirm_new_password: "",
+    },
+    onSubmit: async ({ value }) => {
+      if (!tokens) return
+      setState("submitting")
+      const result = await signIn("reset-password", {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        new_password: value.new_password,
+        redirect: false,
+      })
+      if (result?.ok) {
+        router.replace("/dashboard")
+      } else if (result?.error === "EXPIRED_OR_INVALID_TOKEN") {
+        setErrorMessage(t("resetLinkExpired"))
+        setState("error")
+      } else {
+        setErrorMessage(result?.error ?? t("unexpectedError"))
+        setState("error")
+      }
+    },
+  })
+
+  if (state === "loading") {
+    return (
+      <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6" />
+    )
+  }
+
+  if (state === "error") {
+    return (
+      <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6">
+        <div className="w-full max-w-sm space-y-4 text-center">
+          <p className="text-destructive text-sm font-medium">{errorMessage}</p>
+          <Link
+            href="/forgot-password"
+            className="text-sm underline underline-offset-4 hover:text-primary"
+          >
+            {t("requestNewLink")}
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6">
+      <div className="w-full max-w-sm">
+        <Card>
+          <CardHeader>
+            <div className="flex flex-col items-center gap-2 text-center">
+              <h1 className="text-2xl font-bold">{t("resetPasswordTitle")}</h1>
+              <p className="text-balance text-muted-foreground">
+                {t("resetPasswordSubtitle")}
+              </p>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault()
+                form.handleSubmit()
+              }}
+            >
+              <FieldGroup>
+                <form.Field
+                  name="new_password"
+                  validators={{
+                    onSubmit: ({ value }) => {
+                      if (!value) return t("newPasswordRequired")
+                      if (value.length < 8) return t("newPasswordMin")
+                    },
+                  }}
+                >
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="new_password">
+                        {t("newPassword")}
+                      </FieldLabel>
+                      <Input
+                        id="new_password"
+                        type="password"
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onBlur={field.handleBlur}
+                      />
+                      {field.state.meta.errors.length > 0 && (
+                        <p className="text-destructive text-sm">
+                          {field.state.meta.errors[0]}
+                        </p>
+                      )}
+                    </Field>
+                  )}
+                </form.Field>
+
+                <form.Field
+                  name="confirm_new_password"
+                  validators={{
+                    onSubmit: ({ value, fieldApi }) => {
+                      if (!value) return t("confirmNewPasswordRequired")
+                      if (value !== fieldApi.form.getFieldValue("new_password"))
+                        return t("newPasswordMismatch")
+                    },
+                  }}
+                >
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="confirm_new_password">
+                        {t("confirmNewPassword")}
+                      </FieldLabel>
+                      <Input
+                        id="confirm_new_password"
+                        type="password"
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onBlur={field.handleBlur}
+                      />
+                      {field.state.meta.errors.length > 0 && (
+                        <p className="text-destructive text-sm">
+                          {field.state.meta.errors[0]}
+                        </p>
+                      )}
+                    </Field>
+                  )}
+                </form.Field>
+
+                <form.Subscribe selector={(s) => s.isSubmitting}>
+                  {(isSubmitting) => (
+                    <Field>
+                      <Button
+                        type="submit"
+                        disabled={isSubmitting || state === "submitting"}
+                      >
+                        {isSubmitting || state === "submitting"
+                          ? t("updatingPassword")
+                          : t("updatePassword")}
+                      </Button>
+                    </Field>
+                  )}
+                </form.Subscribe>
+              </FieldGroup>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/[locale]/forgot-password/page.tsx
+++ b/apps/web/app/[locale]/forgot-password/page.tsx
@@ -1,0 +1,11 @@
+import { ForgotPasswordForm } from "@/features/forgot-password/forgot-password-form"
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+      <div className="w-full max-w-sm md:max-w-4xl">
+        <ForgotPasswordForm />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -37,6 +37,42 @@ export const { auth, handlers, signOut } = NextAuth({
       },
     }),
     Credentials({
+      id: "reset-password",
+      credentials: {
+        access_token: {},
+        refresh_token: {},
+        new_password: {},
+      },
+      async authorize(credentials) {
+        const res = await fetch(
+          `${process.env.API_URL ?? "http://api:8000"}/api/v1/auth/reset-password`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              access_token: credentials.access_token,
+              refresh_token: credentials.refresh_token,
+              new_password: credentials.new_password,
+            }),
+          }
+        )
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ detail: "Reset failed" }))
+          throw new Error(err.detail ?? "Reset failed")
+        }
+        const data = await res.json()
+        return {
+          id: data.user_id,
+          name: data.name,
+          email: data.email,
+          currency: data.currency,
+          plan: data.plan ?? "free",
+          access_token: data.access_token,
+          refresh_token: data.refresh_token,
+        }
+      },
+    }),
+    Credentials({
       credentials: {
         email: { label: "Email" },
         password: { label: "Password", type: "password" },

--- a/apps/web/features/forgot-password/forgot-password-form.tsx
+++ b/apps/web/features/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "@tanstack/react-form"
+import { useTranslations } from "next-intl"
+
+import { Button } from "@workspace/ui/components/button"
+import { Card, CardContent, CardHeader } from "@workspace/ui/components/card"
+import {
+  Field,
+  FieldGroup,
+  FieldLabel,
+} from "@workspace/ui/components/field"
+import { Input } from "@workspace/ui/components/input"
+import { Link } from "@/i18n/navigation"
+import { apiFetch } from "@/lib/api"
+
+type State = "idle" | "sending" | "sent"
+
+export function ForgotPasswordForm() {
+  const t = useTranslations("auth")
+  const [state, setState] = useState<State>("idle")
+
+  const form = useForm({
+    defaultValues: {
+      email: "",
+    },
+    onSubmit: async ({ value }) => {
+      setState("sending")
+      try {
+        await apiFetch("/api/v1/auth/forgot-password", {
+          method: "POST",
+          body: JSON.stringify({
+            email: value.email,
+            redirect_to: window.location.origin + "/auth/reset-password",
+          }),
+        })
+      } catch {
+        // Anti-enumeration: always transition to sent, hide network errors
+      }
+      setState("sent")
+    },
+  })
+
+  if (state === "sent") {
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col items-center gap-2 text-center">
+            <h1 className="text-2xl font-bold">{t("resetEmailSent")}</h1>
+            <p className="text-balance text-muted-foreground">
+              {t("resetEmailSentDesc")}
+            </p>
+          </div>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Link
+            href="/login"
+            className="text-sm underline underline-offset-2 hover:text-foreground"
+          >
+            {t("backToLogin")}
+          </Link>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-2xl font-bold">{t("forgotPasswordTitle")}</h1>
+          <p className="text-balance text-muted-foreground">
+            {t("forgotPasswordSubtitle")}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            form.handleSubmit()
+          }}
+        >
+          <FieldGroup>
+            <form.Field
+              name="email"
+              validators={{
+                onSubmit: ({ value }) => {
+                  if (!value) return t("emailRequired")
+                  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
+                    return t("emailInvalid")
+                },
+              }}
+            >
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="email">{t("email")}</FieldLabel>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder={t("emailPlaceholder")}
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onBlur={field.handleBlur}
+                  />
+                  {field.state.meta.errors.length > 0 && (
+                    <p className="text-destructive text-sm">
+                      {field.state.meta.errors[0]}
+                    </p>
+                  )}
+                </Field>
+              )}
+            </form.Field>
+
+            <form.Subscribe selector={(s) => s.isSubmitting}>
+              {(isSubmitting) => (
+                <Field>
+                  <Button type="submit" disabled={isSubmitting || state === "sending"}>
+                    {isSubmitting || state === "sending"
+                      ? t("sendingResetLink")
+                      : t("sendResetLink")}
+                  </Button>
+                </Field>
+              )}
+            </form.Subscribe>
+
+            <div className="text-center">
+              <Link
+                href="/login"
+                className="text-sm underline underline-offset-2 hover:text-foreground"
+              >
+                {t("backToLogin")}
+              </Link>
+            </div>
+          </FieldGroup>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/features/login/login-form.tsx
+++ b/apps/web/features/login/login-form.tsx
@@ -17,6 +17,7 @@ import {
 } from "@workspace/ui/components/field"
 import { Input } from "@workspace/ui/components/input"
 import { useTranslations } from "next-intl"
+import { Link } from "@/i18n/navigation"
 
 export function LoginForm({
   className,
@@ -107,12 +108,12 @@ export function LoginForm({
                   <Field>
                     <div className="flex items-center">
                       <FieldLabel htmlFor="password">{t("password")}</FieldLabel>
-                      <a
-                        href="#"
+                      <Link
+                        href="/forgot-password"
                         className="ml-auto text-sm underline-offset-2 hover:underline"
                       >
                         {t("forgotPassword")}
-                      </a>
+                      </Link>
                     </div>
                     <Input
                       id="password"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -745,7 +745,26 @@
     "confirmFailed": "Confirmation failed. The link may have expired or already been used.",
     "unexpectedError": "An unexpected error occurred. Please try again.",
     "couldNotConfirm": "Could not confirm your account.",
-    "backToLogin": "Back to sign in"
+    "backToLogin": "Back to sign in",
+    "forgotPasswordTitle": "Forgot your password?",
+    "forgotPasswordSubtitle": "Enter your email and we'll send you a reset link.",
+    "sendResetLink": "Send reset link",
+    "sendingResetLink": "Sending...",
+    "resetEmailSent": "Email sent",
+    "resetEmailSentDesc": "Check your inbox. If the email exists, you'll receive a reset link shortly.",
+    "resetPasswordTitle": "Set a new password",
+    "resetPasswordSubtitle": "Enter and confirm your new password.",
+    "newPassword": "New password",
+    "newPasswordRequired": "New password is required",
+    "newPasswordMin": "Minimum 8 characters",
+    "confirmNewPassword": "Confirm new password",
+    "confirmNewPasswordRequired": "Confirm your new password",
+    "newPasswordMismatch": "Passwords do not match",
+    "updatingPassword": "Updating...",
+    "updatePassword": "Update password",
+    "resetLinkExpired": "This link has expired or was already used. Request a new one.",
+    "requestNewLink": "Request new link",
+    "resetSuccess": "Password updated! Redirecting..."
   },
   "public": {
     "nav": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -745,7 +745,26 @@
     "confirmFailed": "La confirmación falló. El enlace puede haber expirado o ya fue usado.",
     "unexpectedError": "Ocurrió un error inesperado. Intenta de nuevo.",
     "couldNotConfirm": "No se pudo confirmar tu cuenta.",
-    "backToLogin": "Volver al inicio de sesión"
+    "backToLogin": "Volver al inicio de sesión",
+    "forgotPasswordTitle": "¿Olvidaste tu contraseña?",
+    "forgotPasswordSubtitle": "Ingresa tu correo y te enviaremos un enlace para restablecerla.",
+    "sendResetLink": "Enviar enlace",
+    "sendingResetLink": "Enviando...",
+    "resetEmailSent": "Correo enviado",
+    "resetEmailSentDesc": "Revisa tu bandeja de entrada. Si el correo existe, recibirás un enlace en breve.",
+    "resetPasswordTitle": "Establece una nueva contraseña",
+    "resetPasswordSubtitle": "Ingresa y confirma tu nueva contraseña.",
+    "newPassword": "Nueva contraseña",
+    "newPasswordRequired": "La nueva contraseña es requerida",
+    "newPasswordMin": "Mínimo 8 caracteres",
+    "confirmNewPassword": "Confirmar nueva contraseña",
+    "confirmNewPasswordRequired": "Confirma tu nueva contraseña",
+    "newPasswordMismatch": "Las contraseñas no coinciden",
+    "updatingPassword": "Actualizando...",
+    "updatePassword": "Actualizar contraseña",
+    "resetLinkExpired": "Este link expiró o ya fue usado. Solicita uno nuevo.",
+    "requestNewLink": "Solicitar nuevo enlace",
+    "resetSuccess": "¡Contraseña actualizada! Redirigiendo..."
   },
   "public": {
     "nav": {


### PR DESCRIPTION
- Add POST /api/v1/auth/forgot-password: calls supabase reset_password_for_email, always returns 200 to prevent email enumeration
- Add POST /api/v1/auth/reset-password: set_session + update_user atomic sequence using access_token/refresh_token from Supabase recovery email hash fragment
- Add reset-password NextAuth Credentials provider (throws on error to propagate EXPIRED_OR_INVALID_TOKEN to client)
- Add /forgot-password page and ForgotPasswordForm component (idle/sending/sent states)
- Add /auth/reset-password page and ResetPasswordClient: reads access_token + refresh_token from window.location.hash on mount (Supabase implicit flow)
- Fix login-form.tsx: replace href="#" with Link href="/forgot-password"
- Add forgotPassword and resetPassword i18n keys to en.json and es.json