### PR TITLE
release: transacciones-programadas

### DIFF
--- a/apps/api/alembic/versions/b1c2d3e4f5a6_add_recurring_columns.py
+++ b/apps/api/alembic/versions/b1c2d3e4f5a6_add_recurring_columns.py
@@ -1,0 +1,40 @@
+"""add recurrence_day_of_month and parent_transaction_id to transactions
+
+Revision ID: b1c2d3e4f5a6
+Revises: a922ce3ebe51
+Create Date: 2026-05-25 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1c2d3e4f5a6'
+down_revision: Union[str, Sequence[str], None] = 'a922ce3ebe51'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('transactions', sa.Column('recurrence_day_of_month', sa.Integer(), nullable=True))
+    op.add_column('transactions', sa.Column('parent_transaction_id', sa.String(), nullable=True))
+    op.create_foreign_key(
+        'fk_transactions_parent_id', 'transactions',
+        'transactions', ['parent_transaction_id'], ['id'],
+        ondelete='SET NULL'
+    )
+    op.create_index('ix_transactions_parent_transaction_id', 'transactions', ['parent_transaction_id'])
+    op.execute(
+        "UPDATE transactions SET recurrence_day_of_month = EXTRACT(DAY FROM date)::INTEGER "
+        "WHERE is_recurring = TRUE AND recurrence = 'monthly'"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_transactions_parent_transaction_id', table_name='transactions')
+    op.drop_constraint('fk_transactions_parent_id', 'transactions', type_='foreignkey')
+    op.drop_column('transactions', 'parent_transaction_id')
+    op.drop_column('transactions', 'recurrence_day_of_month')

--- a/apps/api/src/account/router.py
+++ b/apps/api/src/account/router.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/accounts", tags=["Accounts"])
 CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 
-@router.get("/", response_model=List[AccountResponse])
+@router.get("", response_model=List[AccountResponse])
 async def list_accounts(
     current_user: CurrentUser,
     service: AccountService = Depends(get_account_service),
@@ -29,7 +29,7 @@ async def get_account(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=AccountResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=AccountResponse, status_code=status.HTTP_201_CREATED)
 async def create_account(
     data: AccountCreate,
     current_user: CurrentUser,

--- a/apps/api/src/budget/router.py
+++ b/apps/api/src/budget/router.py
@@ -19,7 +19,7 @@ CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 # --- Budgets ---
 
-@router.get("/", response_model=List[BudgetResponse])
+@router.get("", response_model=List[BudgetResponse])
 async def list_budgets(
     current_user: CurrentUser,
     service: BudgetService = Depends(get_budget_service),
@@ -36,7 +36,7 @@ async def get_budget(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=BudgetResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=BudgetResponse, status_code=status.HTTP_201_CREATED)
 async def create_budget(
     data: BudgetCreate,
     current_user: CurrentUser,

--- a/apps/api/src/category/router.py
+++ b/apps/api/src/category/router.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/categories", tags=["Categories"])
 CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 
-@router.get("/", response_model=List[CategoryResponse])
+@router.get("", response_model=List[CategoryResponse])
 async def list_categories(
     current_user: CurrentUser,
     service: CategoryService = Depends(get_category_service),
@@ -29,7 +29,7 @@ async def get_category(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=CategoryResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=CategoryResponse, status_code=status.HTTP_201_CREATED)
 async def create_category(
     data: CategoryCreate,
     current_user: CurrentUser,

--- a/apps/api/src/credit_card/router.py
+++ b/apps/api/src/credit_card/router.py
@@ -25,7 +25,7 @@ CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 # --- Credit Cards ---
 
-@router.get("/", response_model=List[CreditCardResponse])
+@router.get("", response_model=List[CreditCardResponse])
 async def list_credit_cards(
     current_user: CurrentUser,
     service: CreditCardService = Depends(get_credit_card_service),
@@ -42,7 +42,7 @@ async def get_credit_card(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=CreditCardResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=CreditCardResponse, status_code=status.HTTP_201_CREATED)
 async def create_credit_card(
     data: CreditCardCreate,
     current_user: CurrentUser,

--- a/apps/api/src/loan/router.py
+++ b/apps/api/src/loan/router.py
@@ -18,7 +18,7 @@ CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 # --- Loans ---
 
-@router.get("/", response_model=List[LoanResponse])
+@router.get("", response_model=List[LoanResponse])
 async def list_loans(
     current_user: CurrentUser,
     service: LoanService = Depends(get_loan_service),
@@ -35,7 +35,7 @@ async def get_loan(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=LoanResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=LoanResponse, status_code=status.HTTP_201_CREATED)
 async def create_loan(
     data: LoanCreate,
     current_user: CurrentUser,

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -18,6 +18,7 @@ settings = get_settings()
 app = FastAPI(
     title=settings.app_name,
     version=settings.version,
+    redirect_slashes=False,
 )
 
 origins = settings.ALLOWED_HOSTS

--- a/apps/api/src/permissions/router.py
+++ b/apps/api/src/permissions/router.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/permissions", tags=["Permissions"])
 CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 
-@router.get("/", response_model=List[PermissionResponse])
+@router.get("", response_model=List[PermissionResponse])
 async def list_permissions(
     _: CurrentUser,
     service: PermissionService = Depends(get_permission_service),
@@ -29,7 +29,7 @@ async def get_permission(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=PermissionResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=PermissionResponse, status_code=status.HTTP_201_CREATED)
 async def create_permission(
     data: PermissionCreate,
     _: CurrentUser,

--- a/apps/api/src/saving/router.py
+++ b/apps/api/src/saving/router.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/saving-goals", tags=["Saving Goals"])
 CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 
-@router.get("/", response_model=List[SavingGoalResponse])
+@router.get("", response_model=List[SavingGoalResponse])
 async def list_saving_goals(
     current_user: CurrentUser,
     service: SavingGoalService = Depends(get_saving_goal_service),
@@ -29,7 +29,7 @@ async def get_saving_goal(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=SavingGoalResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=SavingGoalResponse, status_code=status.HTTP_201_CREATED)
 async def create_saving_goal(
     data: SavingGoalCreate,
     current_user: CurrentUser,

--- a/apps/api/src/tasks/recurring_transactions.py
+++ b/apps/api/src/tasks/recurring_transactions.py
@@ -1,11 +1,12 @@
 import asyncio
+import calendar
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date as date_type
 
-from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy import select
+
 from src.celery_app import celery_app
-from src.core.settings import get_settings
-from src.core.utils import generate_uuid
+from src.core.database import _get_session_maker
 from src.core.metadata_models import load_all_models
 from src.transaction.models import TransactionModel
 
@@ -14,71 +15,93 @@ load_all_models()
 logger = logging.getLogger(__name__)
 
 
-async def _run():
-    settings = get_settings()
-    engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    session_maker = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
-    async with session_maker() as session:
-        try:
-            from sqlalchemy import select
+def _compute_target_day(recurrence_day: int, year: int, month: int) -> int:
+    max_day = calendar.monthrange(year, month)[1]
+    return min(recurrence_day, max_day)
 
+
+def _should_generate_monthly(tx: TransactionModel, today: date_type) -> bool:
+    last = tx.last_generated_at
+    if last is None:
+        last_date = tx.date.date() if tx.date else today
+    else:
+        last_date = last.date() if hasattr(last, "date") else last
+    return today.year > last_date.year or (today.year == last_date.year and today.month > last_date.month)
+
+
+async def _run() -> None:
+    today = datetime.now(tz=timezone.utc).date()
+
+    async with _get_session_maker()() as session:
+        try:
             result = await session.execute(
                 select(TransactionModel).where(
                     TransactionModel.is_recurring == True,  # noqa: E712
-                    TransactionModel.recurrence.in_(["weekly", "monthly"]),
+                    TransactionModel.recurrence == "monthly",
+                    TransactionModel.recurrence_day_of_month != None,  # noqa: E711
                 )
             )
-            recurring = list(result.scalars().all())
-
-            now = datetime.now(tz=timezone.utc)
-            today = now.date()
+            templates = result.scalars().all()
             generated = 0
 
-            for tx in recurring:
-                last = tx.last_generated_at
-                if last is None:
-                    last_date = tx.date.date() if tx.date else today
-                else:
-                    last_date = last.date() if hasattr(last, "date") else last
+            for tx in templates:
+                recurrence_day = tx.recurrence_day_of_month or tx.date.day
+                target_day = _compute_target_day(recurrence_day, today.year, today.month)
 
-                should_generate = False
-                if tx.recurrence == "weekly":
-                    should_generate = (today - last_date).days >= 7
-                elif tx.recurrence == "monthly":
-                    should_generate = (
-                        today.year > last_date.year
-                        or (today.year == last_date.year and today.month > last_date.month)
-                    )
-
-                if not should_generate:
+                if today.day != target_day:
                     continue
 
+                if not _should_generate_monthly(tx, today):
+                    logger.info(
+                        "Skipping template %s — already generated for %s-%s",
+                        tx.id, today.year, today.month,
+                    )
+                    continue
+
+                target_date = datetime(today.year, today.month, target_day, 0, 5, 0, tzinfo=timezone.utc)
+
                 new_tx = TransactionModel(
-                    id=generate_uuid(),
                     user_id=tx.user_id,
                     account_id=tx.account_id,
                     category_id=tx.category_id,
                     type=tx.type,
                     amount=tx.amount,
                     description=tx.description,
-                    date=now,
+                    date=target_date,
                     is_recurring=False,
-                    recurrence=None,
+                    recurrence="none",
                     saving_goal_id=tx.saving_goal_id,
+                    parent_transaction_id=tx.id,
                 )
                 session.add(new_tx)
-                tx.last_generated_at = now
+                await session.flush()
+
+                # Adjust account balance (mirrors TransactionService logic)
+                if tx.account_id and tx.amount is not None:
+                    from src.account.models import AccountModel
+                    acc_result = await session.execute(
+                        select(AccountModel).where(AccountModel.id == tx.account_id)
+                    )
+                    account = acc_result.scalars().first()
+                    if account:
+                        if tx.type == "income":
+                            account.balance += tx.amount
+                        elif tx.type == "expense":
+                            account.balance -= tx.amount
+                        await session.flush()
+
+                tx.last_generated_at = datetime.now(tz=timezone.utc)
                 generated += 1
 
             await session.commit()
-            logger.info(f"Recurring transactions: generated {generated} new transactions")
-        except Exception as e:
+            logger.info("Recurring transactions: generated %d copies", generated)
+
+        except Exception as exc:
             await session.rollback()
-            logger.error(f"Error processing recurring transactions: {e}")
+            logger.error("Error processing recurring transactions: %s", exc, exc_info=True)
             raise
-    await engine.dispose()
 
 
 @celery_app.task(name="src.tasks.recurring_transactions.process_recurring")
-def process_recurring():
+def process_recurring() -> None:
     asyncio.run(_run())

--- a/apps/api/src/transaction/models.py
+++ b/apps/api/src/transaction/models.py
@@ -3,6 +3,7 @@ from sqlalchemy import (
     Column,
     ForeignKey,
     Float,
+    Integer,
     String,
     DateTime,
     Boolean,
@@ -42,6 +43,8 @@ class TransactionModel(TimestampMixin, Base):
     is_recurring = Column(Boolean, nullable=False, default=False)
     recurrence = Column(String, nullable=True)  # ENUM: none|weekly|monthly
     last_generated_at = Column(DateTime(timezone=True), nullable=True)
+    recurrence_day_of_month = Column(Integer, nullable=True)
+    parent_transaction_id = Column(String, ForeignKey("transactions.id", ondelete="SET NULL"), nullable=True)
 
     # Optional FKs — solo uno puede tener valor a la vez (ver CheckConstraint)
     transfer_to_account_id = Column(String, ForeignKey("accounts.id"), nullable=True)

--- a/apps/api/src/transaction/repository.py
+++ b/apps/api/src/transaction/repository.py
@@ -117,7 +117,15 @@ class TransactionRepository:
         return result.scalars().all()
 
     async def create(self, data: TransactionCreate) -> TransactionModel:
-        obj = TransactionModel(**data.model_dump())
+        dump = data.model_dump()
+        if (
+            dump.get("is_recurring")
+            and dump.get("recurrence") == "monthly"
+            and dump.get("recurrence_day_of_month") is None
+            and dump.get("date") is not None
+        ):
+            dump["recurrence_day_of_month"] = dump["date"].day
+        obj = TransactionModel(**dump)
         self.db.add(obj)
         await self.db.flush()
         await self.db.refresh(obj)

--- a/apps/api/src/transaction/router.py
+++ b/apps/api/src/transaction/router.py
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/transactions", tags=["Transactions"])
 CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 
-@router.get("/", response_model=List[TransactionResponse])
+@router.get("", response_model=List[TransactionResponse])
 async def list_transactions(
     current_user: CurrentUser,
     service: TransactionService = Depends(get_transaction_service),
@@ -74,7 +74,7 @@ async def get_transaction(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=TransactionResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=TransactionResponse, status_code=status.HTTP_201_CREATED)
 async def create_transaction(
     data: TransactionCreate,
     current_user: CurrentUser,

--- a/apps/api/src/transaction/schemas.py
+++ b/apps/api/src/transaction/schemas.py
@@ -28,6 +28,8 @@ class TransactionBase(BaseModel):
     credit_card_payment_id: Optional[str] = None
     loan_payment_id: Optional[str] = None
     saving_goal_id: Optional[str] = None
+    recurrence_day_of_month: Optional[int] = None
+    parent_transaction_id: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -59,6 +61,7 @@ class TransactionResponse(TransactionBase):
     user_id: str
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    last_generated_at: Optional[datetime] = None
 
     model_config = {"from_attributes": True}
 

--- a/apps/api/src/transaction/services.py
+++ b/apps/api/src/transaction/services.py
@@ -92,16 +92,23 @@ class TransactionService:
         account_id = obj.account_id
         # Apply update
         obj = await self.repository.update(obj, data)
-        # Reverse old balance effect
-        old_src, old_dst = self._balance_delta(old_type, old_amount, old_transfer_to)
-        await self.account_repository.adjust_balance(account_id, -old_src)
-        if old_transfer_to:
-            await self.account_repository.adjust_balance(old_transfer_to, -old_dst)
-        # Apply new balance effect
-        new_src, new_dst = self._balance_delta(obj.type, obj.amount, obj.transfer_to_account_id)
-        await self.account_repository.adjust_balance(account_id, new_src)
-        if obj.transfer_to_account_id:
-            await self.account_repository.adjust_balance(obj.transfer_to_account_id, new_dst)
+        # Only recalculate balance if fields that affect it actually changed
+        balance_fields_changed = (
+            data.type is not None or
+            data.amount is not None or
+            (hasattr(data, "transfer_to_account_id") and data.transfer_to_account_id is not None)
+        )
+        if balance_fields_changed:
+            # Reverse old balance effect
+            old_src, old_dst = self._balance_delta(old_type, old_amount, old_transfer_to)
+            await self.account_repository.adjust_balance(account_id, -old_src)
+            if old_transfer_to:
+                await self.account_repository.adjust_balance(old_transfer_to, -old_dst)
+            # Apply new balance effect
+            new_src, new_dst = self._balance_delta(obj.type, obj.amount, obj.transfer_to_account_id)
+            await self.account_repository.adjust_balance(account_id, new_src)
+            if obj.transfer_to_account_id:
+                await self.account_repository.adjust_balance(obj.transfer_to_account_id, new_dst)
         return obj
 
     async def delete(self, id: str) -> None:

--- a/apps/api/src/user/router.py
+++ b/apps/api/src/user/router.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/users", tags=["Users"])
 CurrentUser = Annotated[UserModel, Depends(get_current_user)]
 
 
-@router.get("/", response_model=List[UserResponse])
+@router.get("", response_model=List[UserResponse])
 async def list_users(
     _: CurrentUser,
     service: UserService = Depends(get_user_service),
@@ -34,7 +34,7 @@ async def get_user(
     return await service.get_or_404(id)
 
 
-@router.post("/", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def create_user(
     data: UserCreate,
     _: CurrentUser,

--- a/apps/web/features/accounts/api.ts
+++ b/apps/web/features/accounts/api.ts
@@ -3,13 +3,13 @@ import type { Account, AccountCreate, AccountUpdate } from "./types"
 
 export const accountApi = {
   list: (token: string) =>
-    apiFetch<Account[]>("/api/v1/accounts/", { token }),
+    apiFetch<Account[]>("/api/v1/accounts", { token }),
 
   get: (id: string, token: string) =>
     apiFetch<Account>(`/api/v1/accounts/${id}`, { token }),
 
   create: (data: AccountCreate, token: string) =>
-    apiFetch<Account>("/api/v1/accounts/", {
+    apiFetch<Account>("/api/v1/accounts", {
       method: "POST",
       body: JSON.stringify(data),
       token,

--- a/apps/web/features/budgets/api.ts
+++ b/apps/web/features/budgets/api.ts
@@ -3,13 +3,13 @@ import type { Budget, BudgetCreate, BudgetUpdate, BudgetItem, BudgetItemCreate, 
 
 export const budgetApi = {
   list: (token: string) =>
-    apiFetch<Budget[]>("/api/v1/budgets/", { token }),
+    apiFetch<Budget[]>("/api/v1/budgets", { token }),
 
   get: (id: string, token: string) =>
     apiFetch<Budget>(`/api/v1/budgets/${id}`, { token }),
 
   create: (data: BudgetCreate, token: string) =>
-    apiFetch<Budget>("/api/v1/budgets/", {
+    apiFetch<Budget>("/api/v1/budgets", {
       method: "POST",
       body: JSON.stringify(data),
       token,

--- a/apps/web/features/categories/api.ts
+++ b/apps/web/features/categories/api.ts
@@ -3,13 +3,13 @@ import type { Category, CategoryCreate, CategoryUpdate } from "./types"
 
 export const categoryApi = {
   list: (token: string) =>
-    apiFetch<Category[]>("/api/v1/categories/", { token }),
+    apiFetch<Category[]>("/api/v1/categories", { token }),
 
   get: (id: string, token: string) =>
     apiFetch<Category>(`/api/v1/categories/${id}`, { token }),
 
   create: (data: CategoryCreate, token: string) =>
-    apiFetch<Category>("/api/v1/categories/", {
+    apiFetch<Category>("/api/v1/categories", {
       method: "POST",
       body: JSON.stringify(data),
       token,

--- a/apps/web/features/credit-cards/api.ts
+++ b/apps/web/features/credit-cards/api.ts
@@ -8,13 +8,13 @@ import type {
 
 export const creditCardApi = {
   list: (token: string) =>
-    apiFetch<CreditCard[]>("/api/v1/credit-cards/", { token }),
+    apiFetch<CreditCard[]>("/api/v1/credit-cards", { token }),
 
   get: (id: string, token: string) =>
     apiFetch<CreditCard>(`/api/v1/credit-cards/${id}`, { token }),
 
   create: (data: CreditCardCreate, token: string) =>
-    apiFetch<CreditCard>("/api/v1/credit-cards/", {
+    apiFetch<CreditCard>("/api/v1/credit-cards", {
       method: "POST",
       body: JSON.stringify(data),
       token,

--- a/apps/web/features/loans/api.ts
+++ b/apps/web/features/loans/api.ts
@@ -3,13 +3,13 @@ import type { Loan, LoanCreate, LoanUpdate, LoanPayment, LoanPaymentCreate, Loan
 
 export const loanApi = {
   list: (token: string) =>
-    apiFetch<Loan[]>("/api/v1/loans/", { token }),
+    apiFetch<Loan[]>("/api/v1/loans", { token }),
 
   get: (id: string, token: string) =>
     apiFetch<Loan>(`/api/v1/loans/${id}`, { token }),
 
   create: (data: LoanCreate, token: string) =>
-    apiFetch<Loan>("/api/v1/loans/", {
+    apiFetch<Loan>("/api/v1/loans", {
       method: "POST",
       body: JSON.stringify(data),
       token,

--- a/apps/web/features/savings/api.ts
+++ b/apps/web/features/savings/api.ts
@@ -3,13 +3,13 @@ import type { SavingGoal, SavingGoalCreate, SavingGoalUpdate } from "./types"
 
 export const savingGoalApi = {
   list: (token: string) =>
-    apiFetch<SavingGoal[]>("/api/v1/saving-goals/", { token }),
+    apiFetch<SavingGoal[]>("/api/v1/saving-goals", { token }),
 
   get: (id: string, token: string) =>
     apiFetch<SavingGoal>(`/api/v1/saving-goals/${id}`, { token }),
 
   create: (data: SavingGoalCreate, token: string) =>
-    apiFetch<SavingGoal>("/api/v1/saving-goals/", {
+    apiFetch<SavingGoal>("/api/v1/saving-goals", {
       method: "POST",
       body: JSON.stringify(data),
       token,

--- a/apps/web/features/transactions/api.ts
+++ b/apps/web/features/transactions/api.ts
@@ -3,7 +3,7 @@ import type { Transaction, TransactionCreate, TransactionUpdate, TransactionPage
 
 export const transactionApi = {
   list: (token: string) =>
-    apiFetch<Transaction[]>("/api/v1/transactions/", { token }),
+    apiFetch<Transaction[]>("/api/v1/transactions", { token }),
 
   listPage: (token: string, params?: { limit?: number; next_token?: string }) => {
     const q = new URLSearchParams()
@@ -16,7 +16,7 @@ export const transactionApi = {
     apiFetch<Transaction>(`/api/v1/transactions/${id}`, { token }),
 
   create: (data: TransactionCreate, token: string) =>
-    apiFetch<Transaction>("/api/v1/transactions/", {
+    apiFetch<Transaction>("/api/v1/transactions", {
       method: "POST",
       body: JSON.stringify(data),
       token,

--- a/apps/web/features/transactions/transaction-form.tsx
+++ b/apps/web/features/transactions/transaction-form.tsx
@@ -568,6 +568,36 @@ export function TransactionForm({
           </>
         )}
 
+        {isEditing && initialValues?.is_recurring && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20 px-3 py-2.5 flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium text-amber-800 dark:text-amber-300">{t("stopRecurrenceTitle")}</p>
+              <p className="text-xs text-amber-700 dark:text-amber-400">{t("stopRecurrenceDesc")}</p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="shrink-0 border-amber-300 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-900/30"
+              onClick={async () => {
+                try {
+                  const tx = await transactionApi.update(
+                    initialValues.id,
+                    { is_recurring: false, recurrence: "none" },
+                    token
+                  )
+                  toast.success(t("recurrenceStopped"))
+                  onSuccess(tx)
+                } catch {
+                  toast.error(t("errorSaving"))
+                }
+              }}
+            >
+              {t("stopRecurrence")}
+            </Button>
+          </div>
+        )}
+
         <div className="flex gap-2 justify-end pt-1">
           <Button type="button" variant="outline" onClick={onCancel}>
             {t("cancel")}

--- a/apps/web/features/transactions/transaction-list.tsx
+++ b/apps/web/features/transactions/transaction-list.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react"
 import {
   Plus, Pencil, Trash2,
   ArrowUpCircle, ArrowDownCircle, ArrowRightLeft, PiggyBank, ReceiptText,
-  Filter, X, Download, Loader2, ChevronLeft, ChevronRight,
+  Filter, X, Download, Loader2, ChevronLeft, ChevronRight, RefreshCw,
 } from "lucide-react"
 import { useLocale, useTranslations } from "next-intl"
 import type { ExportCsvLabels } from "./export-csv"
@@ -457,6 +457,15 @@ export function TransactionList({ token, isPro, userName, userEmail, initialTran
                               <span className="text-xs text-muted-foreground" suppressHydrationWarning>
                                 {new Date(tx.date).toLocaleTimeString(LOCALE_TAG[locale], { hour: "2-digit", minute: "2-digit" })}
                               </span>
+                              {tx.is_recurring && (
+                                <>
+                                  <span className="text-xs text-muted-foreground">·</span>
+                                  <Badge variant="secondary" className="text-xs h-5 px-2 gap-1">
+                                    <RefreshCw className="size-2.5" />
+                                    {t("recurringBadge")}
+                                  </Badge>
+                                </>
+                              )}
                             </div>
                           </div>
 

--- a/apps/web/features/transactions/types.ts
+++ b/apps/web/features/transactions/types.ts
@@ -11,6 +11,8 @@ export interface Transaction {
   recurrence?: "none" | "weekly" | "monthly" | null
   transfer_to_account_id?: string | null
   saving_goal_id?: string | null
+  recurrence_day_of_month?: number | null
+  parent_transaction_id?: string | null
   created_at?: string
   updated_at?: string
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -214,7 +214,12 @@
     "reportYearLabel": "Year",
     "reportNoExpenses": "No expenses registered",
     "reportMonthExpenses": "Expenses for {month} {year}",
-    "reportTopExpenses": "Top expenses for {year}"
+    "reportTopExpenses": "Top expenses for {year}",
+    "recurringBadge": "Recurring",
+    "stopRecurrenceTitle": "Stop recurrence",
+    "stopRecurrenceDesc": "Future automatic copies will not be generated.",
+    "stopRecurrence": "Stop",
+    "recurrenceStopped": "Recurrence stopped"
   },
   "accounts": {
     "title": "My Accounts",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -214,7 +214,12 @@
     "reportYearLabel": "Año",
     "reportNoExpenses": "Sin gastos registrados",
     "reportMonthExpenses": "Gastos de {month} {year}",
-    "reportTopExpenses": "Top gastos del año {year}"
+    "reportTopExpenses": "Top gastos del año {year}",
+    "recurringBadge": "Recurrente",
+    "stopRecurrenceTitle": "Detener recurrencia",
+    "stopRecurrenceDesc": "No se generarán más copias automáticas.",
+    "stopRecurrence": "Detener",
+    "recurrenceStopped": "Recurrencia detenida"
   },
   "accounts": {
     "title": "Mis Cuentas",


### PR DESCRIPTION
## Summary

Merge develop → main.

Includes the `transacciones-programadas` feature:
- Scheduled monthly recurring transactions by exact day-of-month with short-month clamping
- Alembic migration: `recurrence_day_of_month` + `parent_transaction_id` columns
- Celery Beat task rewritten with idempotency guard and balance adjustment
- Recurring badge in transaction list + stop-recurrence UI in edit form
- Fix: trailing slash 307 redirect loop (FastAPI `redirect_slashes=False`, routes without slash, frontend paths normalized)
- Fix: balance recalculation skipped on non-financial updates (category, description, recurrence flag)