### PR TITLE
feat: fix dashboard CC charges and move budget alerts to notifications

### DIFF
--- a/apps/web/app/[locale]/(protected)/layout.tsx
+++ b/apps/web/app/[locale]/(protected)/layout.tsx
@@ -4,6 +4,8 @@ import "@workspace/ui/globals.css"
 import { getTranslations } from "next-intl/server"
 import { auth } from "@/auth"
 import { signOutAction } from "@/lib/actions"
+import { budgetApi, budgetItemApi } from "@/features/budgets/api"
+import { computeBudgetAlerts } from "@/features/budgets/alerts"
 import { ProtectedSidebar } from "@/components/protected-sidebar"
 import { SidebarInset, SidebarProvider } from "@workspace/ui/components/sidebar"
 import { SiteHeader } from "@workspace/ui/components/site-header"
@@ -26,6 +28,27 @@ export default async function DashboardLayout({
     redirect("/login")
   }
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true"
+
+  // Compute current-month budget alert count for the user-menu badge
+  let alertCount = 0
+  try {
+    const token = session.accessToken ?? ""
+    const now = new Date()
+    const budgets = await budgetApi.list(token)
+    const currentBudget = budgets.find(
+      (b) => b.month === now.getMonth() + 1 && b.year === now.getFullYear()
+    )
+    if (currentBudget) {
+      const items = await budgetItemApi.list(currentBudget.id, token)
+      alertCount = computeBudgetAlerts(
+        items,
+        currentBudget.alert_warning_pct,
+        currentBudget.alert_danger_pct
+      ).length
+    }
+  } catch {
+    alertCount = 0
+  }
 
   const navItemConfigs = [
     { key: "dashboard"    as const, title: tNav("dashboard"),    url: "/dashboard" },
@@ -54,6 +77,7 @@ export default async function DashboardLayout({
         variant="inset"
         brand={{ name: tNav("brandName"), tagline: tNav("brandTagline") }}
         navItemConfigs={navItemConfigs}
+        alertCount={alertCount}
         user={{
           name: session?.user.name ?? "",
           email: session?.user.email ?? "",

--- a/apps/web/app/[locale]/(protected)/notifications/page.tsx
+++ b/apps/web/app/[locale]/(protected)/notifications/page.tsx
@@ -1,0 +1,58 @@
+import { Bell } from "lucide-react"
+import { getTranslations } from "next-intl/server"
+import { auth } from "@/auth"
+import { budgetApi, budgetItemApi } from "@/features/budgets/api"
+import { categoryApi } from "@/features/categories/api"
+import type { Budget, BudgetItem } from "@/features/budgets/types"
+import type { Category } from "@/features/categories/types"
+import { BudgetAlerts } from "@/features/dashboard/budget-alerts"
+
+export default async function NotificationsPage() {
+  const session = await auth()
+  const token = session?.accessToken ?? ""
+  const t = await getTranslations("notifications")
+
+  const now = new Date()
+  let currentBudget: Budget | undefined
+  let budgetItems: BudgetItem[] = []
+  let categories: Category[] = []
+
+  try {
+    const [budgets, cats] = await Promise.all([
+      budgetApi.list(token),
+      categoryApi.list(token).catch(() => [] as Category[]),
+    ])
+    categories = cats
+    currentBudget = budgets.find(
+      (b) => b.month === now.getMonth() + 1 && b.year === now.getFullYear()
+    )
+    if (currentBudget) {
+      budgetItems = await budgetItemApi.list(currentBudget.id, token).catch(() => [])
+    }
+  } catch {
+    // Token expired or invalid — render empty state
+  }
+
+  return (
+    <div className="p-6 flex flex-col gap-6">
+      <div className="rounded-xl border bg-card overflow-hidden">
+        <div className="flex items-center gap-4 px-6 py-5">
+          <div className="flex items-center justify-center size-12 rounded-lg bg-primary/10 shrink-0">
+            <Bell className="size-6 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-xl font-bold">{t("title")}</h1>
+            <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
+          </div>
+        </div>
+      </div>
+      <BudgetAlerts
+        budgetItems={budgetItems}
+        categories={categories}
+        warningPct={currentBudget?.alert_warning_pct ?? 80}
+        dangerPct={currentBudget?.alert_danger_pct ?? 100}
+        emptyText={t("empty")}
+      />
+    </div>
+  )
+}

--- a/apps/web/components/protected-sidebar.tsx
+++ b/apps/web/components/protected-sidebar.tsx
@@ -12,13 +12,14 @@ import {
   CreditCard,
   BarChart3,
   TrendingUp,
+  Bell,
   Check,
   Sun,
   Moon,
   Monitor,
 } from "lucide-react"
 import { useLocale, useTranslations } from "next-intl"
-import { useRouter, usePathname } from "@/i18n/navigation"
+import { Link, useRouter, usePathname } from "@/i18n/navigation"
 import { useTheme } from "next-themes"
 import { AppSidebar } from "@workspace/ui/components/app-sidebar"
 import {
@@ -58,14 +59,16 @@ interface ProtectedSidebarProps extends ComponentProps<typeof Sidebar> {
   navItemConfigs: NavItemConfig[]
   user: { name: string; email: string; avatar?: string; plan?: string }
   navUserLabels: NavUserLabels
+  alertCount: number
 }
 
-function SidebarUserExtras() {
+function SidebarUserExtras({ alertCount }: { alertCount: number }) {
   const locale = useLocale() as Locale
   const router = useRouter()
   const pathname = usePathname()
   const { theme, setTheme } = useTheme()
   const t = useTranslations("settings")
+  const tNav = useTranslations("nav")
   const tLang = useTranslations("languageSwitcher")
 
   function handleLocale(next: string) {
@@ -76,6 +79,18 @@ function SidebarUserExtras() {
 
   return (
     <>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem asChild>
+        <Link href="/notifications">
+          <Bell className="size-4" />
+          {tNav("notifications")}
+          {alertCount > 0 && (
+            <span className="ml-auto inline-flex items-center justify-center rounded-full bg-red-500/15 text-red-600 dark:text-red-400 text-[10px] font-semibold px-1.5 min-w-5 h-5">
+              {alertCount}
+            </span>
+          )}
+        </Link>
+      </DropdownMenuItem>
       <DropdownMenuSeparator />
       <DropdownMenuGroup>
         <DropdownMenuLabel className="px-2 py-1 text-xs font-normal text-muted-foreground">
@@ -115,11 +130,11 @@ function SidebarUserExtras() {
   )
 }
 
-export function ProtectedSidebar({ navItemConfigs, ...props }: ProtectedSidebarProps) {
+export function ProtectedSidebar({ navItemConfigs, alertCount, ...props }: ProtectedSidebarProps) {
   const navItems = navItemConfigs.map(({ key, title, url }) => ({
     title,
     url,
     icon: NAV_ICONS[key],
   }))
-  return <AppSidebar {...props} navItems={navItems} navUserExtras={<SidebarUserExtras />} />
+  return <AppSidebar {...props} navItems={navItems} navUserExtras={<SidebarUserExtras alertCount={alertCount} />} />
 }

--- a/apps/web/features/budgets/alerts.ts
+++ b/apps/web/features/budgets/alerts.ts
@@ -1,0 +1,42 @@
+import type { BudgetItem } from "./types"
+
+export interface BudgetAlert {
+  itemId: string
+  level: "warning" | "danger"
+  categoryId: string | null
+  description: string
+  spent: number
+  planned: number
+  pct: number
+}
+
+/**
+ * Pure helper: derives over-threshold budget alerts from budget items.
+ * Category-name resolution is left to the caller (renderers resolve from their
+ * own categories list); this keeps the helper free of a categories dependency
+ * so callers that only need the count (e.g. the protected layout) stay light.
+ */
+export function computeBudgetAlerts(
+  items: BudgetItem[],
+  warningPct = 80,
+  dangerPct = 100,
+): BudgetAlert[] {
+  const result: BudgetAlert[] = []
+  for (const item of items) {
+    if (item.planned_amount <= 0) continue
+    const spent = item.actual_amount ?? (item.is_paid ? item.planned_amount : 0)
+    if (spent <= 0) continue
+    const pct = (spent / item.planned_amount) * 100
+    if (pct < warningPct) continue
+    result.push({
+      itemId: item.id,
+      level: pct >= dangerPct ? "danger" : "warning",
+      categoryId: item.category_id ?? null,
+      description: item.description,
+      spent,
+      planned: item.planned_amount,
+      pct,
+    })
+  }
+  return result.sort((a, b) => b.pct - a.pct)
+}

--- a/apps/web/features/dashboard/budget-alerts.tsx
+++ b/apps/web/features/dashboard/budget-alerts.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, XCircle, X, Bell } from "lucide-react"
 import { useTranslations } from "next-intl"
 import type { BudgetItem } from "@/features/budgets/types"
 import type { Category } from "@/features/categories/types"
+import { computeBudgetAlerts } from "@/features/budgets/alerts"
 import { useCurrency } from "@/hooks/use-currency"
 
 interface BudgetAlertsProps {
@@ -12,15 +13,8 @@ interface BudgetAlertsProps {
   categories: Category[]
   warningPct?: number
   dangerPct?: number
-}
-
-interface Alert {
-  id: string
-  level: "warning" | "danger"
-  categoryName: string
-  spent: number
-  planned: number
-  pct: number
+  /** When provided, renders an empty-state card instead of null when there are no alerts. */
+  emptyText?: string
 }
 
 export function BudgetAlerts({
@@ -28,36 +22,30 @@ export function BudgetAlerts({
   categories,
   warningPct = 80,
   dangerPct = 100,
+  emptyText,
 }: BudgetAlertsProps) {
   const [dismissed, setDismissed] = useState<Set<string>>(new Set())
   const t = useTranslations("dashboard")
 
   const categoryMap = Object.fromEntries(categories.map((c) => [c.id, c.name]))
 
-  const alerts = useMemo<Alert[]>(() => {
-    const result: Alert[] = []
-    for (const item of budgetItems) {
-      if (item.planned_amount <= 0) continue
-      const spent = item.actual_amount ?? (item.is_paid ? item.planned_amount : 0)
-      if (spent === 0) continue
-      const pct = (spent / item.planned_amount) * 100
-      if (pct < warningPct) continue
-      result.push({
-        id: item.id,
-        level: pct >= dangerPct ? "danger" : "warning",
-        categoryName: (item.category_id ? categoryMap[item.category_id] : null) ?? item.description,
-        spent,
-        planned: item.planned_amount,
-        pct,
-      })
-    }
-    return result.sort((a, b) => b.pct - a.pct)
-  }, [budgetItems, categoryMap, warningPct, dangerPct])
-
-  const visible = alerts.filter((a) => !dismissed.has(a.id))
-  if (visible.length === 0) return null
+  const alerts = useMemo(
+    () => computeBudgetAlerts(budgetItems, warningPct, dangerPct),
+    [budgetItems, warningPct, dangerPct]
+  )
 
   const fmt = useCurrency()
+
+  const visible = alerts.filter((a) => !dismissed.has(a.itemId))
+  if (visible.length === 0) {
+    if (!emptyText) return null
+    return (
+      <div className="rounded-xl border bg-card px-6 py-10 text-center">
+        <Bell className="size-8 text-muted-foreground/40 mx-auto mb-3" />
+        <p className="text-sm text-muted-foreground">{emptyText}</p>
+      </div>
+    )
+  }
 
   return (
     <div className="rounded-xl border bg-card overflow-hidden">
@@ -70,9 +58,10 @@ export function BudgetAlerts({
       <div className="divide-y">
         {visible.map((alert) => {
           const isDanger = alert.level === "danger"
+          const categoryName = (alert.categoryId ? categoryMap[alert.categoryId] : null) ?? alert.description
           return (
             <div
-              key={alert.id}
+              key={alert.itemId}
               className={`flex items-center gap-4 px-5 py-3.5 ${
                 isDanger ? "bg-red-500/5" : "bg-yellow-500/5"
               }`}
@@ -84,7 +73,7 @@ export function BudgetAlerts({
               )}
 
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate">{alert.categoryName}</p>
+                <p className="text-sm font-medium truncate">{categoryName}</p>
                 <p className={`text-xs mt-0.5 ${isDanger ? "text-red-500" : "text-yellow-600 dark:text-yellow-400"}`}>
                   {isDanger
                     ? t("budgetExceeded", { spent: fmt(alert.spent), planned: fmt(alert.planned) })
@@ -107,7 +96,7 @@ export function BudgetAlerts({
 
               <button
                 type="button"
-                onClick={() => setDismissed((prev) => new Set(prev).add(alert.id))}
+                onClick={() => setDismissed((prev) => new Set(prev).add(alert.itemId))}
                 className="size-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
                 title={t("dismissAlert")}
               >

--- a/apps/web/features/dashboard/dashboard-content.tsx
+++ b/apps/web/features/dashboard/dashboard-content.tsx
@@ -12,6 +12,7 @@ import {
   Landmark,
   ChevronRight,
   Target,
+  AlertTriangle,
 } from "lucide-react"
 import { useLocale, useTranslations } from "next-intl"
 import type { Transaction } from "@/features/transactions/types"
@@ -24,7 +25,7 @@ import { parseDateParts, fmtDateLocal, LOCALE_TAG } from "@/lib/dates"
 import type { Locale } from "@/i18n/routing"
 import { useCurrency } from "@/hooks/use-currency"
 import { TrendCharts } from "./trend-charts"
-import { BudgetAlerts } from "./budget-alerts"
+import { computeBudgetAlerts } from "@/features/budgets/alerts"
 import { RecurringSummary } from "./recurring-summary"
 import { PremiumGate } from "@/components/premium-gate"
 
@@ -120,6 +121,15 @@ export function DashboardContent({
   }, [transactions])
 
 
+  const alertCount = useMemo(
+    () => computeBudgetAlerts(
+      budgetItems,
+      currentBudget?.alert_warning_pct ?? 80,
+      currentBudget?.alert_danger_pct ?? 100,
+    ).length,
+    [budgetItems, currentBudget]
+  )
+
   const totalPlanned = budgetItems.reduce((s, i) => s + i.planned_amount, 0)
   const totalSpentOnBudget = budgetItems.reduce((s, i) => {
     const spent = i.actual_amount ?? (i.is_paid ? i.planned_amount : 0)
@@ -181,14 +191,16 @@ export function DashboardContent({
         />
       </div>
 
-      {/* Budget Alerts — Pro only */}
-      {isPro && (
-        <BudgetAlerts
-          budgetItems={budgetItems}
-          categories={categories}
-          warningPct={currentBudget?.alert_warning_pct ?? 80}
-          dangerPct={currentBudget?.alert_danger_pct ?? 100}
-        />
+      {/* Budget Alerts — compact banner linking to /notifications (Pro only) */}
+      {isPro && alertCount > 0 && (
+        <Link
+          href="/notifications"
+          className="flex items-center gap-3 rounded-xl border border-yellow-500/30 bg-yellow-500/5 px-5 py-3 hover:bg-yellow-500/10 transition-colors"
+        >
+          <AlertTriangle className="size-4 text-yellow-500 shrink-0" />
+          <span className="text-sm font-medium flex-1">{t("alertsBannerText", { count: alertCount })}</span>
+          <ChevronRight className="size-4 text-muted-foreground shrink-0" />
+        </Link>
       )}
 
       {/* Recurring this month */}
@@ -235,7 +247,7 @@ export function DashboardContent({
                 {recentTransactions.map((t) => {
                   const category = t.category_id ? categoryMap[t.category_id] : null
                   const account = t.account_id ? accountMap[t.account_id] : undefined
-                  const isExpense = t.type === "expense"
+                  const isNegative = t.type === "expense" || t.type === "credit_card_charge"
                   return (
                     <tr key={t.id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
                       <td className="px-6 py-3 text-muted-foreground whitespace-nowrap text-xs">
@@ -253,8 +265,8 @@ export function DashboardContent({
                       <td className="px-6 py-3">
                         <TypeBadge type={t.type} />
                       </td>
-                      <td className={`px-6 py-3 text-right font-bold tabular-nums ${isExpense ? "text-red-500" : "text-green-500"}`}>
-                        {isExpense ? "−" : "+"}{fmt(t.amount)}
+                      <td className={`px-6 py-3 text-right font-bold tabular-nums ${isNegative ? "text-red-500" : "text-green-500"}`}>
+                        {isNegative ? "−" : "+"}{fmt(t.amount)}
                       </td>
                     </tr>
                   )

--- a/apps/web/features/dashboard/trend-charts.tsx
+++ b/apps/web/features/dashboard/trend-charts.tsx
@@ -77,7 +77,8 @@ export function TrendCharts({ transactions, categories }: TrendChartsProps) {
     const now = new Date()
     const map: Record<string, number> = {}
     for (const tx of transactions) {
-      if (tx.type !== "expense" || !tx.category_id) continue
+      if (!tx.category_id) continue
+      if (tx.type !== "expense" && tx.type !== "credit_card_charge") continue
       const d = new Date(tx.date)
       if (d.getMonth() !== now.getMonth() || d.getFullYear() !== now.getFullYear()) continue
       map[tx.category_id] = (map[tx.category_id] ?? 0) + tx.amount

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -39,6 +39,7 @@
     "reports": "Reports",
     "categories": "Categories",
     "settings": "Settings",
+    "notifications": "Notifications",
     "signOut": "Sign out",
     "brandName": "Budgets Map",
     "brandTagline": "Financial Solution"
@@ -103,6 +104,7 @@
     "accountTypeDigitalWallet": "Digital wallet",
     "budgetAlerts": "Budget alerts",
     "alertCount": "{count, plural, one {# alert} other {# alerts}}",
+    "alertsBannerText": "{count, plural, one {# budget alert} other {# budget alerts}}",
     "budgetExceeded": "Budget exceeded — you spent {spent} of {planned}",
     "budgetWarning": "{pct}% used — you spent {spent} of {planned}",
     "dismissAlert": "Dismiss alert",
@@ -673,6 +675,11 @@
     "categoryUpdated": "Category updated",
     "errorSaving": "Error saving category",
     "countCategories": "{count} categories"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "subtitle": "Alerts from your budgets",
+    "empty": "No alerts right now. Everything's under control."
   },
   "settings": {
     "profile": "Profile",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -39,6 +39,7 @@
     "reports": "Reportes",
     "categories": "Categorías",
     "settings": "Configuración",
+    "notifications": "Notificaciones",
     "signOut": "Cerrar sesión",
     "brandName": "Budgets Map",
     "brandTagline": "Solución Financiera"
@@ -103,6 +104,7 @@
     "accountTypeDigitalWallet": "Billetera digital",
     "budgetAlerts": "Alertas de presupuesto",
     "alertCount": "{count, plural, one {# alerta} other {# alertas}}",
+    "alertsBannerText": "{count, plural, one {# alerta de presupuesto} other {# alertas de presupuesto}}",
     "budgetExceeded": "Presupuesto superado — gastaste {spent} de {planned}",
     "budgetWarning": "{pct}% usado — gastaste {spent} de {planned}",
     "dismissAlert": "Descartar alerta",
@@ -673,6 +675,11 @@
     "categoryUpdated": "Categoría actualizada",
     "errorSaving": "Error al guardar la categoría",
     "countCategories": "{count} categorías"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "subtitle": "Alertas de tus presupuestos",
+    "empty": "No tienes alertas por ahora. Todo bajo control."
   },
   "settings": {
     "profile": "Perfil",


### PR DESCRIPTION
  - Show credit-card charges as negative/red in the dashboard recent transactions table (were rendering positive/green)
  - Include credit_card_charge in the 'expenses by category' chart; monthly expense totals stay unchanged to avoid double-counting with the bank payment (which has no category)
  - Extract a shared computeBudgetAlerts helper (features/budgets/alerts.ts)
  - Move budget alerts out of the dashboard into a dedicated /notifications page, reachable from a Notificaciones item in the user menu with an alert-count badge
  - Replace the invasive dashboard alerts card with a compact one-line banner linking to /notifications, shown only when alerts exist
  - Fix a latent hooks-order bug in budget-alerts.tsx (useCurrency was called after a conditional return)